### PR TITLE
feat: Adding the `component` and `part-of` attributes to devfile

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,6 +7,8 @@ metadata:
 components:
   - name: devworkspace-telemetry-woopra-plugin
     attributes:
+      app.kubernetes.io/component: che-theia
+      app.kubernetes.io/part-of: che-theia.eclipse.org
       workspaceEnv:
         - name: DEVWORKSPACE_TELEMETRY_BACKEND_PORT
           value: '4167'

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,7 +7,7 @@ metadata:
 components:
   - name: devworkspace-telemetry-woopra-plugin
     attributes:
-      app.kubernetes.io/component: che-theia
+      app.kubernetes.io/component: telemetry
       app.kubernetes.io/part-of: che-theia.eclipse.org
       workspaceEnv:
         - name: DEVWORKSPACE_TELEMETRY_BACKEND_PORT


### PR DESCRIPTION
The attributes would allow `theia` to hide the container on UI based 

the filtering mechanism on the che-theia end - [https://github.com/eclipse-che/che-theia/blob/489918ff1690a6bf16fcea91c675ac95f494[…]ia-terminal/src/browser/contribution/terminal-command-filter.ts](https://github.com/eclipse-che/che-theia/blob/489918ff1690a6bf16fcea91c675ac95f49478ec/extensions/eclipse-che-theia-terminal/src/browser/contribution/terminal-command-filter.ts#L47-L49)