### PR TITLE
fix: support text/plain context-type for the woopra domain and segmen…

### DIFF
--- a/src/main/java/com/redhat/devworkspace/services/telemetry/woopra/MainConfiguration.java
+++ b/src/main/java/com/redhat/devworkspace/services/telemetry/woopra/MainConfiguration.java
@@ -35,10 +35,4 @@ public class MainConfiguration extends BaseConfiguration {
 
     @ConfigProperty(name = "woopra.domain.endpoint")
     Optional<String> woopraDomainEndpoint;
-
-
-    @Produces
-    public HttpJsonRequestFactory httpJsonRequestFactory() {
-        return new DefaultHttpJsonRequestFactory();
-    }
 }

--- a/src/test/java/com/redhat/devworkspace/services/telemetry/woopra/AnalyticsManagerStartupTest.java
+++ b/src/test/java/com/redhat/devworkspace/services/telemetry/woopra/AnalyticsManagerStartupTest.java
@@ -29,7 +29,6 @@ public class AnalyticsManagerStartupTest {
 
         assertThrows(WoopraCredentialException.class, () -> {
             AnalyticsManager am = new AnalyticsManager(config,
-                    null,
                     new MockDevworkspaceFinder(),
                     new MockUsernameFinder(),
                     null,
@@ -43,7 +42,6 @@ public class AnalyticsManagerStartupTest {
 
         assertThrows(WoopraCredentialException.class, () -> {
             AnalyticsManager am = new AnalyticsManager(config,
-                    null,
                     new MockDevworkspaceFinder(),
                     new MockUsernameFinder(),
                     null,


### PR DESCRIPTION
…t write key endpoints

Done by using HttpUrlConnectionProvider instead of HttpJsonRequest

Signed-off-by: David Kwon <dakwon@redhat.com>

Previously, `DefaultHttpJsonRequest` was being used to make a make a requests to the woopra domain and segment write key endpoints, however, `DefaultHttpJsonRequest` only supports the `application/json` content type.

In addition, the documentation on the readme [here](https://github.com/che-incubator/devworkspace-telemetry-woopra-plugin#setting-segment-and-woopra-credentials) and on the upstream docs [here](https://www.eclipse.org/che/docs/stable/administration-guide/the-woopra-telemetry-plugin/) does not mention that the endpoints must provide JSON (and in what format?) in the response body. 

So for now, this PR removes any usage of `DefaultHttpJsonRequest` and replaces it with `HttpUrlConnectionProvider` to simply read the response body as a one-line string.