### PR TITLE
chore: add tests for accessing endpoints for Woopra and Segment details

### DIFF
--- a/src/main/java/com/redhat/devworkspace/services/telemetry/woopra/AnalyticsManager.java
+++ b/src/main/java/com/redhat/devworkspace/services/telemetry/woopra/AnalyticsManager.java
@@ -126,8 +126,8 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
 
     private void setSegmentWriteKey(MainConfiguration config, HttpUrlConnectionProvider httpUrlConnectionProvider) {
         if (config.segmentWriteKey.isEmpty() && config.segmentWriteKeyEndpoint.isEmpty()) {
-            throw new WoopraCredentialException("Requires a segment write key or the URL of an endpoint that will return the segment write key.  " +
-                    " Set either SEGMENT_WRITE_KEY or SEGMENT_WRITE_KEY_ENDPOINT");
+            throw new WoopraCredentialException("Requires a Segment write key or the URL of an endpoint that will return the Segment write key. " +
+                    "Set either SEGMENT_WRITE_KEY or SEGMENT_WRITE_KEY_ENDPOINT");
         } else if (config.segmentWriteKey.isEmpty()) {
             segmentWriteKey = tryRequestFromUrl(config.segmentWriteKeyEndpoint.get(), httpUrlConnectionProvider);
         } else {
@@ -137,8 +137,8 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
 
     private void setWoopraDomain(MainConfiguration config, HttpUrlConnectionProvider httpUrlConnectionProvider) {
         if (config.woopraDomain.isEmpty() && config.woopraDomainEndpoint.isEmpty()) {
-            throw new WoopraCredentialException("Requires a woopra domain or the URL of an endpoint that will return the woopra domain." +
-                    " Set either WOOPRA_DOMAIN or WOOPRA_DOMAIN_ENDPOINT");
+            throw new WoopraCredentialException("Requires a Woopra domain or the URL of an endpoint that will return the Woopra domain. " +
+                    "Set either WOOPRA_DOMAIN or WOOPRA_DOMAIN_ENDPOINT");
         } else if (config.woopraDomain.isEmpty()) {
             woopraDomain = tryRequestFromUrl(config.woopraDomainEndpoint.get(), httpUrlConnectionProvider);
         } else {

--- a/src/test/java/com/redhat/devworkspace/services/telemetry/woopra/AnalyticsManagerStartupTest.java
+++ b/src/test/java/com/redhat/devworkspace/services/telemetry/woopra/AnalyticsManagerStartupTest.java
@@ -12,63 +12,170 @@
 package com.redhat.devworkspace.services.telemetry.woopra;
 
 import com.redhat.devworkspace.services.telemetry.woopra.exception.WoopraCredentialException;
-import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
-import org.eclipse.che.incubator.workspace.telemetry.finder.DevWorkspaceFinder;
-import org.eclipse.che.incubator.workspace.telemetry.finder.UsernameFinder;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
 
-import java.util.Optional;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.slf4j.LoggerFactory.getLogger;
 
 public class AnalyticsManagerStartupTest {
 
+    private static TestHttpServer server;
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        server = new TestHttpServer();
+        server.start();
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        server.stop();
+    }
+
     @Test
     public void willNotStartWithoutWriteKey() {
-        MainConfiguration config = createMainConfiguration(null, null);
+        MainConfiguration config = new MainConfigurationBuilder()
+                .woopraDomain("woopra.domain")
+                .build();
 
         assertThrows(WoopraCredentialException.class, () -> {
-            AnalyticsManager am = new AnalyticsManager(config,
-                    new MockDevworkspaceFinder(),
-                    new MockUsernameFinder(),
-                    null,
-                    null);
-        });
+            AnalyticsManager am = new TestAnalyticsManager(config);
+        }, "Requires a Segment write key or the URL of an endpoint that will return the Segment write key. " +
+                "Set either SEGMENT_WRITE_KEY or SEGMENT_WRITE_KEY_ENDPOINT");
     }
 
     @Test
     public void willNotStartWithoutWoopraDomain() {
-        MainConfiguration config = createMainConfiguration("segmentWriteKey", null);
+        MainConfiguration config = new MainConfigurationBuilder()
+                .segmentWriteKey("segment.write.key")
+                .build();
 
         assertThrows(WoopraCredentialException.class, () -> {
-            AnalyticsManager am = new AnalyticsManager(config,
-                    new MockDevworkspaceFinder(),
-                    new MockUsernameFinder(),
-                    null,
-                    null);
+            AnalyticsManager am = new TestAnalyticsManager(config);
+        }, "Requires a Woopra domain or the URL of an endpoint that will return the Woopra domain. " +
+                "Set either WOOPRA_DOMAIN or WOOPRA_DOMAIN_ENDPOINT");
+    }
+
+    @Test
+    public void readWoopraDomainFromEndpoint() {
+        MainConfiguration config = new MainConfigurationBuilder()
+                .segmentWriteKey("segment.write.key")
+                .woopraDomainEndpoint(TestHttpServer.ROUTE_URL + "?body=woopra.domain")
+                .build();
+        AnalyticsManager am = new TestAnalyticsManager(config);
+        assertEquals("woopra.domain", am.woopraDomain);
+    }
+
+    @Test
+    public void readSegmentWriteKeyFromEndpoint() {
+        MainConfiguration config = new MainConfigurationBuilder()
+                .woopraDomain("woopra.domain")
+                .segmentWriteKeyEndpoint(TestHttpServer.ROUTE_URL + "?body=segment.write.key")
+                .build();
+        AnalyticsManager am = new TestAnalyticsManager(config);
+        assertEquals("segment.write.key", am.segmentWriteKey);
+    }
+
+    @Test
+    public void readWoopraDomainAndSegmentWriteKeyFromEndpoint() {
+        MainConfiguration config = new MainConfigurationBuilder()
+                .woopraDomainEndpoint(TestHttpServer.ROUTE_URL + "?body=woopra.domain")
+                .segmentWriteKeyEndpoint(TestHttpServer.ROUTE_URL + "?body=segment.write.key")
+                .build();
+        AnalyticsManager am = new TestAnalyticsManager(config);
+        assertEquals("woopra.domain", am.woopraDomain);
+        assertEquals("segment.write.key", am.segmentWriteKey);
+    }
+
+    @Test
+    public void readWoopraDomainAndSegmentWriteKey() {
+        MainConfiguration config = new MainConfigurationBuilder()
+                .woopraDomain("woopra.domain")
+                .segmentWriteKey("segment.write.key")
+                .build();
+        AnalyticsManager am = new TestAnalyticsManager(config);
+        assertEquals("woopra.domain", am.woopraDomain);
+        assertEquals("segment.write.key", am.segmentWriteKey);
+    }
+
+    @Test
+    public void doNotReadWoopraDomainAndSegmentWriteKeyFromEndpoints() {
+        MainConfiguration config = new MainConfigurationBuilder()
+                .woopraDomain("woopra.domain")
+                .segmentWriteKey("segment.write.key")
+                .woopraDomainEndpoint(TestHttpServer.ROUTE_URL + "?body=woopra.domain.from.endpoint")
+                .segmentWriteKeyEndpoint(TestHttpServer.ROUTE_URL + "?body=segment.write.key.from.endpoint")
+                .build();
+        AnalyticsManager am = new TestAnalyticsManager(config);
+        assertEquals("woopra.domain", am.woopraDomain);
+        assertEquals("segment.write.key", am.segmentWriteKey);
+    }
+}
+
+class TestAnalyticsManager extends AnalyticsManager {
+    public TestAnalyticsManager(MainConfiguration config) {
+        super(config,
+                new MockDevworkspaceFinder(),
+                new MockUsernameFinder(),
+                null,
+                new HttpUrlConnectionProvider());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}
+
+/**
+ * Simple HTTP server.
+ *
+ * GET request to '{ROUTE_URL}?body=test' results in a response
+ * with a Content-type of 'text/plain' and a response body of 'test'
+ */
+class TestHttpServer {
+    public static final int PORT = 8888;
+    public static final String HOSTNAME = "localhost";
+    public static final String PATH = "/";
+    public static final String ROUTE_URL = "http://" + HOSTNAME + ":" + PORT + PATH;
+
+    private static final Logger LOG = getLogger(TestHttpServer.class);
+
+    private HttpServer server = null;
+
+    public void start() throws Exception {
+        LOG.info("Creating socket address with hostname: {} and port: {}", HOSTNAME, PORT);
+        server = HttpServer.create(new InetSocketAddress(HOSTNAME, PORT), 0);
+        server.createContext(PATH, new HttpHandler() {
+            @Override
+            public void handle(HttpExchange httpExchange) throws IOException {
+                String response = httpExchange.getRequestURI().toString().split("\\?body")[1].split("=")[1];
+                OutputStream outputStream = httpExchange.getResponseBody();
+                httpExchange.getResponseHeaders().put("Content-Type", Collections.singletonList("text/plain"));
+                httpExchange.sendResponseHeaders(200, response.length());
+                outputStream.write(response.getBytes());
+                outputStream.flush();
+                outputStream.close();
+            }
         });
+        server.start();
     }
 
-    private MainConfiguration createMainConfiguration(String segmentWriteKey, String woopraDomain) {
-        MainConfiguration config = new MainConfiguration();
-        config.segmentWriteKey = segmentWriteKey == null ? Optional.empty() : Optional.of(segmentWriteKey);
-        config.woopraDomain = woopraDomain == null ? Optional.empty() : Optional.of(woopraDomain);
-        config.segmentWriteKeyEndpoint = Optional.empty();
-        config.woopraDomainEndpoint = Optional.empty();
-        return config;
-    }
-
-    private class MockDevworkspaceFinder implements DevWorkspaceFinder {
-        @Override
-        public GenericKubernetesResource findDevWorkspace(String devworkspaceId) {
-            return null;
-        }
-    }
-
-    private class MockUsernameFinder implements UsernameFinder {
-        @Override
-        public String findUsername() {
-            return "test-username";
+    public void stop() {
+        if (server != null) {
+            server.stop(0);
         }
     }
 }

--- a/src/test/java/com/redhat/devworkspace/services/telemetry/woopra/MainConfigurationBuilder.java
+++ b/src/test/java/com/redhat/devworkspace/services/telemetry/woopra/MainConfigurationBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.devworkspace.services.telemetry.woopra;
+
+import java.util.Optional;
+
+public class MainConfigurationBuilder {
+
+    private Optional<String> segmentWriteKey;
+    private Optional<String> woopraDomain;
+    private Optional<String> segmentWriteKeyEndpoint;
+    private Optional<String> woopraDomainEndpoint;
+
+    public MainConfigurationBuilder() {
+        this.segmentWriteKey = Optional.empty();
+        this.woopraDomain = Optional.empty();
+        this.segmentWriteKeyEndpoint = Optional.empty();
+        this.woopraDomainEndpoint = Optional.empty();
+    }
+
+    public MainConfigurationBuilder segmentWriteKey(String segmentWriteKey) {
+        this.segmentWriteKey = Optional.of(segmentWriteKey);
+        return this;
+    }
+
+    public MainConfigurationBuilder woopraDomain(String woopraDomain) {
+        this.woopraDomain = Optional.of(woopraDomain);
+        return this;
+    }
+
+    public MainConfigurationBuilder segmentWriteKeyEndpoint(String segmentWriteKeyEndpoint) {
+        this.segmentWriteKeyEndpoint = Optional.of(segmentWriteKeyEndpoint);
+        return this;
+    }
+
+    public MainConfigurationBuilder woopraDomainEndpoint(String woopraDomainEndpoint) {
+        this.woopraDomainEndpoint = Optional.of(woopraDomainEndpoint);
+        return this;
+    }
+
+    public MainConfiguration build() {
+        MainConfiguration config = new MainConfiguration();
+        config.segmentWriteKey = this.segmentWriteKey;
+        config.woopraDomain = this.woopraDomain;
+        config.segmentWriteKeyEndpoint = this.segmentWriteKeyEndpoint;
+        config.woopraDomainEndpoint = this.woopraDomainEndpoint;
+        return config;
+    }
+}


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

This PR adds tests for the fix from https://github.com/che-incubator/devworkspace-telemetry-woopra-plugin/pull/15

To test the ability to read the Woopra domain and Segment write key from an endpoint, the there is a small http server that is  being started.

To test this PR, check out this PR and run `mvn test`. There should be 8 passing tests:
```
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17.940 s
[INFO] Finished at: 2022-07-27T11:52:50-04:00
[INFO] ------------------------------------------------------------------------

```