### PR TITLE
Chore: update ubuntu to 22.04 and actions to use node 16 for #21763

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,9 +10,9 @@ on:
       - main
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: DeLaGuardo/setup-graalvm@5.0
         with:
           graalvm: '21.3.1'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,9 +10,9 @@ on:
       - main
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: DeLaGuardo/setup-graalvm@5.0
         with:
           graalvm: '21.3.0'


### PR DESCRIPTION
Signed-off-by: sdawley <sdawley@redhat.com>
Addresses https://github.com/eclipse/che/issues/21763